### PR TITLE
Update Zone Actions For Records

### DIFF
--- a/gcpdns.py
+++ b/gcpdns.py
@@ -106,7 +106,7 @@ class DNSClient(dns.Client):
         """
         self.get_zone(zone_name).delete()
 
-    def dump_zones(self):
+    def dump_zones(self, records=False):
         """
         Outputs all managed zones  for the project in JSON and CSV format
 
@@ -524,11 +524,13 @@ def _delete_zone(ctx, name):
               multiple=True,
               help="One or more output file paths that end in .csv or .json "
                    "(suppresses screen output).")
+@click.option("--records", "-r", is_flag=True,
+              help="Whether to add the record data to the zone information or not.")
 @click.pass_context
-def _dump_zones(ctx, format_, output):
+def _dump_zones(ctx, format_, output, records):
     """Dump a list of DNS zones."""
     try:
-        zones = ctx.obj.client.dump_zones()
+        zones = ctx.obj.client.dump_zones(records)
         if len(output) == 0:
             click.echo(zones[format_])
         else:

--- a/gcpdns.py
+++ b/gcpdns.py
@@ -323,6 +323,7 @@ class DNSClient(dns.Client):
         - ``dns_name``    - The zone's DNS name
         - ``gcp_name``    - The zone's name in GCP (optional)
         - ``description`` - The zone's description (optional)
+        - ``record_info`` - The zone's records name and type (optional)
 
         Args:
             csv_file: A file or file-like object
@@ -352,6 +353,17 @@ class DNSClient(dns.Client):
             description = None
             if "description" in row:
                 description = row["description"]
+            if "record_info" in row and action == "delete":
+                record_info = row["record_info"]
+                records = record_info.split("|")
+                for r in records:
+                    if r:
+                        data = r.split(":")
+                        try:
+                            self.delete_record_set(data[1], data[0])
+                        except RecordSetNotFound as rsnf:
+                            logger.warning(f"Record set could not be found: {r}")
+                            raise rsnf
             if action == "delete":
                 try:
                     self.delete_zone(dns_name)


### PR DESCRIPTION
This PR does 2 things:
1. Allows for a -r flag to be added to a zone dump to allow for the Zone records to be added (except for NS and SOA).
     a. This updates both the CSV and JSON outputs.
     b. When a CSV output, this separates the record information in the same way nameservers are separated.

2. Allows for records to be provided during a Zone CSV "update" that will allow for records to be deleted before the zone is deleted.
**Note**: This has only been updated to take action on a delete action of the zone csv update.